### PR TITLE
refactor NXxcps application definition

### DIFF
--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -89,8 +89,8 @@
         <field name="g2" type="NX_NUMBER" units="NX_ANY">
           <doc>values for the one-dimensional correlation as function of delay time (tau):</doc>
         </field>
-        <field name="g2_stderr" type="NX_NUMBER" units="NX_ANY">
-          <doc>standard deviation error values for the g2 correlation values:</doc>
+        <field name="g2_errors" type="NX_NUMBER" units="NX_ANY">
+          <doc>Standard deviation error values for the g2 correlation values.</doc>
         </field>
         <field name="tau" type="NX_INT" units="NX_ANY">
           <doc>

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -94,10 +94,13 @@
         </field>
         <field name="tau" type="NX_INT" units="NX_ANY">
           <doc>
-          delay time corresponding to the g2 correlation values
-          TODO clarify:
-          t_el, this is integer delta frame units, not time elapsed units
+          Delay time corresponding to the g2 correlation values.
           </doc>
+          <!--
+            TODO: clarify this additional text, also where does it belong?
+
+            ``t_el``, this is integer delta frame units, not time elapsed units
+          -->
         </field>
       </group>
       <group type="NXdata" name="twotime">

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -76,21 +76,42 @@
       </doc>
     </field>
 
-    <group type="NXdata" name="xpcs">
-      <field name="frame_sum" type="NX_NUMBER" units="NX_ANY">
-        <doc>average intensity v. time</doc>
-      </field>
-      <field name="g2" type="NX_NUMBER" units="NX_ANY">
-        <doc>time correlation function</doc>
-      </field>
-      <field name="g2_stderr" type="NX_NUMBER" units="NX_ANY">
-        <doc>estimated uncertainty of the time correlation function</doc>
-      </field>
-      <field name="tau" type="NX_INT" units="NX_ANY">
-        <doc>
-        delay time, multitau
-
-        TODO: https://github.com/lightsources/BES-XPCS-Pilot/pull/38#discussion_r627008771
+    <group type="NXprocess" name="XPCS">
+      <!-- TODO: -->
+      <group type="NXdata" name="data">
+        <!-- TODO: -->
+        <field name="frame_sum" type="NX_NUMBER" units="NX_ANY">
+          <doc>twodimensional average along the frames stack
+               average intensity v. time
+          </doc>
+        </field>
+        <field name="g2" type="NX_NUMBER" units="NX_ANY">
+          <doc>values for the one-dimensional correlation as function of delay time (tau):</doc>
+        </field>
+        <field name="g2_stderr" type="NX_NUMBER" units="NX_ANY">
+          <doc>standard deviation error values for the g2 correlation values:</doc>
+        </field>
+        <field name="tau" type="NX_INT" units="NX_ANY">
+          <doc>
+          delay time corresponding to the g2 correlation values
+          TODO clarify:
+          t_el, this is integer delta frame units, not time elapsed units
+          </doc>
+        </field>
+      </group>
+      <group type="NXdata" name="twotime">
+        <!-- TODO: -->
+        <field name="C2" type="NX_NUMBER" units="NX_ANY">
+          <doc>two-dimensional Twotime correlation</doc>
+        </field>
+        <field name="g2_twotime" type="NX_NUMBER" units="NX_ANY">
+          <doc>g2full, sum across the diagonals of C2</doc>
+        </field>
+        <field name="g2_partials_twotime" type="NX_NUMBER" units="NX_ANY">
+          <doc>g2 by subset of frames</doc>
+        </field>
+      </group>
+    </group>
 
         t_el, this is integer delta frame units, not time elapsed units
         </doc>

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -81,8 +81,9 @@
       <group type="NXdata" name="data">
         <!-- TODO: -->
         <field name="frame_sum" type="NX_NUMBER" units="NX_ANY">
-          <doc>twodimensional average along the frames stack
-               average intensity v. time
+          <doc>
+            two-dimensional average along the frames stack
+            average intensity v. time
           </doc>
         </field>
         <field name="g2" type="NX_NUMBER" units="NX_ANY">
@@ -111,11 +112,6 @@
           <doc>g2 by subset of frames</doc>
         </field>
       </group>
-    </group>
-
-        t_el, this is integer delta frame units, not time elapsed units
-        </doc>
-      </field>
     </group>
     <group type="NXdata" name="twotime">
       <!--

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -90,6 +90,8 @@
         <doc>
         delay time, multitau
 
+        TODO: https://github.com/lightsources/BES-XPCS-Pilot/pull/38#discussion_r627008771
+
         t_el, this is integer delta frame units, not time elapsed units
         </doc>
       </field>

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -76,16 +76,15 @@
       </doc>
     </field>
 
-    <group type="NXdata" name="data">
-      <!-- TODO: -->
+    <group type="NXdata" name="xpcs">
       <field name="frame_sum" type="NX_NUMBER" units="NX_ANY">
         <doc>average intensity v. time</doc>
       </field>
       <field name="g2" type="NX_NUMBER" units="NX_ANY">
-        <doc>TODO:</doc>
+        <doc>time correlation function</doc>
       </field>
       <field name="g2_stderr" type="NX_NUMBER" units="NX_ANY">
-        <doc>TODO:</doc>
+        <doc>estimated uncertainty of the time correlation function</doc>
       </field>
       <field name="tau" type="NX_INT" units="NX_ANY">
         <doc>
@@ -96,7 +95,10 @@
       </field>
     </group>
     <group type="NXdata" name="twotime">
-      <!-- TODO: -->
+      <!--
+          TODO: Scientists want a different name for this group?
+                What is the new name?
+      -->
       <field name="C2" type="NX_NUMBER" units="NX_ANY">
         <doc>two-time correlation</doc>
       </field>
@@ -111,13 +113,11 @@
     <group type="NXinstrument" name="instrument">
       <doc>XPCS Metadata</doc>
       <group type="NXmonochromator" name="monochromator">
-        <!-- TODO: verify with fields defined in base class -->
         <field name="energy" type="NX_FLOAT" units="NX_ENERGY">
           <doc>Incident beam line energy (either keV or eV).</doc>
         </field>
       </group>
       <group type="NXdetector" name="detector">
-        <!-- TODO: verify with fields defined in base class -->
         <field name="description">
           <doc>Detector name.</doc>
         </field>

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -76,64 +76,58 @@
       </doc>
     </field>
 
-    <group type="NXprocess" name="XPCS">
-      <!-- TODO: -->
-      <group type="NXdata" name="data">
-        <!-- TODO: -->
-        <field name="frame_sum" type="NX_NUMBER" units="NX_ANY">
-          <doc>
-            two-dimensional average along the frames stack
-            average intensity v. time
-          </doc>
-        </field>
-        <field name="g2" type="NX_NUMBER" units="NX_ANY">
-          <doc>values for the one-dimensional correlation as function of delay time (tau):</doc>
-        </field>
-        <field name="g2_errors" type="NX_NUMBER" units="NX_ANY">
-          <doc>Standard deviation error values for the g2 correlation values.</doc>
-        </field>
-        <field name="tau" type="NX_INT" units="NX_ANY">
-          <doc>
-          Delay time corresponding to the g2 correlation values.
-          </doc>
-          <!--
-            TODO: clarify this additional text, also where does it belong?
+    <group type="NXdata" name="data">
+      <field name="frame_sum" type="NX_NUMBER" units="NX_ANY">
+        <doc>
+          Two-dimensional average along the frames stack.
 
-            ``t_el``, this is integer delta frame units, not time elapsed units
-          -->
-        </field>
-      </group>
-      <group type="NXdata" name="twotime">
-        <!-- TODO: -->
-        <field name="C2" type="NX_NUMBER" units="NX_ANY">
-          <doc>two-dimensional Twotime correlation</doc>
-        </field>
-        <field name="g2_twotime" type="NX_NUMBER" units="NX_ANY">
-          <doc>g2full, sum across the diagonals of C2</doc>
-        </field>
-        <field name="g2_partials_twotime" type="NX_NUMBER" units="NX_ANY">
-          <doc>g2 by subset of frames</doc>
-        </field>
-      </group>
+          average intensity v. time
+        </doc>
+      </field>
+      <field name="g2" type="NX_NUMBER" units="NX_ANY">
+        <doc>One-dimensional time correlation as function of delay time (tau).</doc>
+      </field>
+      <field name="g2_errors" type="NX_NUMBER" units="NX_ANY">
+        <!-- NeXus convention calls this "_errors" even if it is std. dev. -->
+        <doc>
+            Standard deviation of the g2 correlation values.
+        </doc>
+      </field>
+      <field name="tau" type="NX_INT" units="NX_ANY">
+        <doc>
+        Delay time corresponding to the g2 correlation values.  As in :math:`g_2(\tau)`.
+        </doc>
+        <!--
+          TODO: clarify this additional text, also where does it belong?
+
+          ``t_el``, this is integer delta frame units, not time elapsed units
+        -->
+      </field>
     </group>
+
     <group type="NXdata" name="twotime">
       <!--
           TODO: Scientists want a different name for this group?
                 What is the new name?
       -->
       <field name="C2" type="NX_NUMBER" units="NX_ANY">
-        <doc>two-time correlation</doc>
+        <doc>Two-time correlation, two-dimensional.</doc>
       </field>
       <field name="g2_twotime" type="NX_NUMBER" units="NX_ANY">
-        <doc>g2full, sum across the diagonals of C2</doc>
+        <doc>Sum across the diagonals of ``C2``.  Also known as ``g2full``.</doc>
       </field>
       <field name="g2_partials_twotime" type="NX_NUMBER" units="NX_ANY">
-        <doc>g2 by subset of frames</doc>
+        <doc>``g2`` by subset of frames.</doc>
       </field>
     </group>
 
     <group type="NXinstrument" name="instrument">
-      <doc>XPCS Metadata</doc>
+      <doc>
+          XPCS instrument Metadata.
+
+          Objects can entered here directly or linked from other
+          objects in the NeXus file (such as within ``/entry/instrument``).
+      </doc>
       <group type="NXmonochromator" name="monochromator">
         <field name="energy" type="NX_FLOAT" units="NX_ENERGY">
           <doc>Incident beam line energy (either keV or eV).</doc>
@@ -147,7 +141,7 @@
           <doc>Distance between sample and detector.</doc>
         </field>
         <field name="count_time" type="NX_NUMBER" units="NX_TIME">
-          <doc>Exposure time of frames, s</doc>
+          <doc>Exposure time of frames, s.</doc>
         </field>
         <field name="frame_time" type="NX_NUMBER" units="NX_TIME">
           <doc>
@@ -178,6 +172,13 @@
 
       <group type="NXnote" name="masks" minOccurs="0" maxOccurs="1">
           <doc>
+              Data masks or mappings to regions of interest.
+
+              Fields in this ``masks`` group describe regions of interest
+              in the data by either a mask to select pixels or to associate
+              a *map* of ROIs with a (one-dimensional) *list* of values.
+          </doc>
+              <!--  FIXME: removed this archaic doc text.  It's different below.
               Data masks could be defined using either NXarraymask
               or NXparameterizedmask.
 
@@ -203,8 +204,7 @@
                           ]
                       mask_names:NX_CHAR[9] = Q=0.002
                       usage:NX_CHAR = Selective
-
-          </doc>
+              -->
           <field name="mask" type="NX_NUMBER">
             <doc>
             ROI mask

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -76,146 +76,48 @@
       </doc>
     </field>
 
-    <group type="NXprocess" name="XPCS">
+    <group type="NXdata" name="data">
       <!-- TODO: -->
-      <group type="NXdata" name="data">
-        <!-- TODO: -->
-        <field name="frame_sum" type="NX_NUMBER" units="NX_ANY">
-          <doc>average intensity v. time</doc>
-        </field>
-        <field name="g2" type="NX_NUMBER" units="NX_ANY">
-          <doc>TODO:</doc>
-        </field>
-        <field name="g2_stderr" type="NX_NUMBER" units="NX_ANY">
-          <doc>TODO:</doc>
-        </field>
-        <field name="tau" type="NX_INT" units="NX_ANY">
-          <doc>
-          delay time, multitau
+      <field name="frame_sum" type="NX_NUMBER" units="NX_ANY">
+        <doc>average intensity v. time</doc>
+      </field>
+      <field name="g2" type="NX_NUMBER" units="NX_ANY">
+        <doc>TODO:</doc>
+      </field>
+      <field name="g2_stderr" type="NX_NUMBER" units="NX_ANY">
+        <doc>TODO:</doc>
+      </field>
+      <field name="tau" type="NX_INT" units="NX_ANY">
+        <doc>
+        delay time, multitau
 
-          t_el, this is integer delta frame units, not time elapsed units
-          </doc>
-        </field>
-      </group>
-      <group type="NXdata" name="twotime">
-        <!-- TODO: -->
-        <field name="C2" type="NX_NUMBER" units="NX_ANY">
-          <doc>two-time correlation</doc>
-        </field>
-        <field name="g2_twotime" type="NX_NUMBER" units="NX_ANY">
-          <doc>g2full, sum across the diagonals of C2</doc>
-        </field>
-        <field name="g2_partials_twotime" type="NX_NUMBER" units="NX_ANY">
-          <doc>g2 by subset of frames</doc>
-        </field>
-      </group>
+        t_el, this is integer delta frame units, not time elapsed units
+        </doc>
+      </field>
     </group>
-
-    <group type="NXcanSAS" name="SAXS_1D">
-      <!--
-        https://manual.nexusformat.org/classes/applications/NXcanSAS.html
-
-        TODO: Should this be type="NXsubentry" with definition field of NXcanSAS?
-
-        Structure from our initial example file:
-
-            SAXS_1D:NXsubentry
-              @NX_class = NXsubentry
-              @canSAS_class = SASentry
-              @default = data
-              definition:NX_CHAR = NXcanSAS
-              instrument -> /entry/instrument
-              run -> /entry/title
-              sample -> /entry/sample
-              title:NX_CHAR = static 1D SAXS from XPCS data
-              data:NXdata
-                @I_axes = Q
-                @NX_class = NXdata
-                @Q_indices = 0
-                @canSAS_class = SASdata
-                @signal = I
-                I:NX_FLOAT32[270] = [0.27429348, 0.34260944, 0.2445109, '...', 0.0057929275]
-                  @units = arbitrary
-                  @units_details = Photon/Pixel/Frame
-                Q:NX_FLOAT64[270] = [0.0018368, 0.00186642, 0.001891, '...', 0.063412]
-                  @units = 1/angstrom ->
-
-      -->
-      <doc>Additions to the NXcanSAS definition.</doc>
-      <group type="NXdata" name="data">
-        <field name="I_partial" type="NX_NUMBER">
-          <doc>
-            I(Q) for stability plot.
-
-            Q: Should units match I?
-          </doc>
-        </field>
-        <!-- defined in NXcanSAS -->
-        <field name="I" type="NX_NUMBER" />
-        <field name="Q" type="NX_NUMBER" units="NX_PER_LENGTH" />
-      </group>
-    </group>
-
-    <group type="NXcanSAS" name="SAXS_2D">
-      <!--
-        https://manual.nexusformat.org/classes/applications/NXcanSAS.html
-
-        TODO: Should this be type="NXsubentry" with definition field of NXcanSAS?
-
-          SAXS_2D:NXsubentry
-            @NX_class = NXsubentry
-            @canSAS_class = SASentry
-            @default = data
-            definition:NX_CHAR = NXcanSAS
-            instrument -> /entry/instrument
-            run -> /entry/title
-            sample -> /entry/sample
-            title:NX_CHAR = static 2D SAXS from XPCS data
-            data:NXdata
-              @NX_class = NXdata
-              @canSAS_class = SASdata
-              @mask = mask
-              @signal = I
-              I:NX_FLOAT32[516,1556] = __array
-                __array = [
-                    [0.0029529633, 0.0049402798, 0.006318577, '...', 0.0109847365]
-                    [0.0043127504, 0.004439526, 0.005501271, '...', 0.004218236]
-                    [0.008683259, 0.0066289976, 0.003876593, '...', 0.0056484076]
-                    ...
-                    [0.004690421, 0.0072740484, 0.0053803907, '...', 0.0039639533]
-                  ]
-                @units = arbitrary
-                @units_details = Photon/Pixel/Frame
-              mask:NX_INT64[516,1556] = __array
-                __array = [
-                    [0, 0, 0, '...', 0]
-                    [0, 0, 0, '...', 0]
-                    [0, 0, 0, '...', 0]
-                    ...
-                    [0, 0, 0, '...', 0]
-                  ]
-                @units = boolean
-
-      -->
-      <doc>Additions to the NXcanSAS definition.</doc>
-      <!-- TODO: any?-->
-      <!-- defined in NXcanSAS -->
-      <group type="NXdata" name="data">
-        <field name="I" type="NX_NUMBER" />
-        <field name="Q" type="NX_NUMBER" units="NX_PER_LENGTH" />
-      </group>
+    <group type="NXdata" name="twotime">
+      <!-- TODO: -->
+      <field name="C2" type="NX_NUMBER" units="NX_ANY">
+        <doc>two-time correlation</doc>
+      </field>
+      <field name="g2_twotime" type="NX_NUMBER" units="NX_ANY">
+        <doc>g2full, sum across the diagonals of C2</doc>
+      </field>
+      <field name="g2_partials_twotime" type="NX_NUMBER" units="NX_ANY">
+        <doc>g2 by subset of frames</doc>
+      </field>
     </group>
 
     <group type="NXinstrument" name="instrument">
       <doc>XPCS Metadata</doc>
       <group type="NXmonochromator" name="monochromator">
-      <!-- TODO: verify with fields defined in base class -->
+        <!-- TODO: verify with fields defined in base class -->
         <field name="energy" type="NX_FLOAT" units="NX_ENERGY">
           <doc>Incident beam line energy (either keV or eV).</doc>
         </field>
       </group>
       <group type="NXdetector" name="detector">
-      <!-- TODO: verify with fields defined in base class -->
+        <!-- TODO: verify with fields defined in base class -->
         <field name="description">
           <doc>Detector name.</doc>
         </field>
@@ -330,7 +232,7 @@
           <!-- <group type="NXparameterizedmask" minOccurs="0" maxOccurs="unbounded" /> -->
       </group>
     </group>
-
+  
     <group type="NXsample" name="sample">
       <field name="temperature_set" type="NX_NUMBER" units="NX_TEMPERATURE">
         <doc>
@@ -345,11 +247,6 @@
       <group type="NXpositioner" name="position_x" />
       <group type="NXpositioner" name="position_y" />
       <group type="NXpositioner" name="position_z" />
-    </group>
-
-    <group type="NXdata" name="data">
-        <!-- TODO: here, link to datasets -->
-        <doc>Describes the default view.  Link to datasets as needed.</doc>
     </group>
 
     <group type="NXnote" name="ROI" minOccurs="0" maxOccurs="unbounded">


### PR DESCRIPTION
As written, the NXxpcs application XML file has included the reduced SAXS data (which is covered by NXcanSAS).  This is not part of the reduced XPCS data.  Refactor the proposed NeXus application definition to only specify data within the NXxpcs application definition.  This will fix #35.