### PR TITLE
MNT #43 replace NXmonochromator with NXbeam

### DIFF
--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -147,6 +147,7 @@
         </field>
         <field name="extent" type="NX_FLOAT" units="NX_LENGTH">
           <doc>Size (2-D) of the beam at this position.</doc>
+          <!-- FIXME: (h, v) or (v, h)?  State this in the docs-->
         </field>
       </group>
       <group type="NXdetector" name="detector">

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -132,13 +132,21 @@
         <field name="incident_energy" type="NX_FLOAT" units="NX_ENERGY">
           <doc>Incident beam line energy (either keV or eV).</doc>
         </field>
-        <field name="incident_polarization">
+        <field name="incident_energy_spread" type="NX_FLOAT" units="NX_ENERGY">
+          <doc>
+            Spread of incident beam line energy (either keV or eV).
+          </doc>
+        </field>
+        <field name="incident_polarization_type">
           <doc>
             Terse description of the incident beam polarization.
 
             The value can be plain text, such as ``vertical``, ``C+``,
            ``circular left``.
           </doc>
+        </field>
+        <field name="extent" type="NX_FLOAT" units="NX_LENGTH">
+          <doc>Size (2-D) of the beam at this position.</doc>
         </field>
       </group>
       <group type="NXdetector" name="detector">
@@ -262,7 +270,7 @@
           <!-- <group type="NXparameterizedmask" minOccurs="0" maxOccurs="unbounded" /> -->
       </group>
     </group>
-  
+
     <group type="NXsample" name="sample">
       <field name="temperature_set" type="NX_NUMBER" units="NX_TEMPERATURE">
         <doc>
@@ -284,7 +292,7 @@
           Region(s) of interest.
 
           NAME: The NeXus convention is to use all upper case
-          to indicate the name (here ``ROI``) is left to the file 
+          to indicate the name (here ``ROI``) is left to the file
           writer.  In our case, follow the suggested name
           pattern and sequence: roi_1, roi_2, roi_3, ...
           Start with ``roi_1`` if the first one, otherwise
@@ -297,7 +305,7 @@
           Any other notes.
 
           NAME: The NeXus convention is to use all upper case
-          to indicate the name (here ``NOTE``) is left to the file 
+          to indicate the name (here ``NOTE``) is left to the file
           writer.  In our case, follow the suggested name
           pattern and sequence: note_1, note_2, note_3, ...
           Start with ``note_1`` if the first one, otherwise

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -128,9 +128,17 @@
           Objects can entered here directly or linked from other
           objects in the NeXus file (such as within ``/entry/instrument``).
       </doc>
-      <group type="NXmonochromator" name="monochromator">
-        <field name="energy" type="NX_FLOAT" units="NX_ENERGY">
+      <group type="NXbeam" name="incident_beam">
+        <field name="incident_energy" type="NX_FLOAT" units="NX_ENERGY">
           <doc>Incident beam line energy (either keV or eV).</doc>
+        </field>
+        <field name="incident_polarization">
+          <doc>
+            Terse description of the incident beam polarization.
+
+            The value can be plain text, such as ``vertical``, ``C+``,
+           ``circular left``.
+          </doc>
         </field>
       </group>
       <group type="NXdetector" name="detector">


### PR DESCRIPTION
Fix #43 by:

* replacing `monochromator`NXmonochromator (NXmonochromator) group with `incident_beam` (NXbeam) group
* relocating `monochromator/energy` into `incident_beam/incident_energy` (consistent with NeXus field name)
* creating `incident_beam/incident_polarization` (consistent with NeXus field name)