### PR TITLE
Better descriptive documentation

### DIFF
--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -121,8 +121,8 @@
                 <description>2D array with shape ($g_2$, q) </description>
               </item>
 
-              **QUESTION** should we add a sketch of g2 plot with error bars and delay_difference as 
-              an illustratory example?
+              **QUESTION** should we add a sketch of g2 plot with error bars, delay_difference, and 
+              baseline as an illustratory example?
 
               **QUESTION** should we talk more about expected length of data (we have not length 
               consistency checks).  These checks are probably up to developers, but by docummenting

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -88,14 +88,14 @@
         <doc>
           Two-dimensional summation along the frames stack.
 
-          sum of intensity v. time
+          sum of intensity v. time (in the units of "frames")
         </doc>
       </field>
       <field name="frame_average" type="NX_NUMBER" units="NX_COUNT" minOccurs="0" maxOccurs="1">
         <doc>
             Two-dimensional average along the frames stack.
 
-            average intensity v. time
+            average intensity v. time (in the units of "frames")
         </doc>
       </field>
       <field name="g2" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -294,7 +294,7 @@
 
       <group type="NXnote" name="masks" minOccurs="0" maxOccurs="1">
           <doc>
-              Data masks or mappings to regions of interest.
+              Data masks or mappings to regions of interest (roi).
 
               Fields in this ``masks`` group describe regions of interest
               in the data by either a mask to select pixels or to associate
@@ -302,10 +302,11 @@
           </doc>
           <field name="dynamic_roi_map" type="NX_DIMENSIONLESS">
             <doc>
-            ROI index array.
+            ROI index array, or labeled array.
 
-            The values of this mask index the $Q$ value from the
-            the ``dynamic_q_list`` field.
+            The values of this mask index (or map to) the $Q$ value from the
+            the ``dynamic_q_list`` field. Not that the value of ``0`` represents in-action. XPCS compuatations 
+            are performed on all pixels with a value > 0.
 
             The ``units`` attribute should be set to ``"au"``
             indicating arbitrary units.
@@ -314,11 +315,15 @@
           <field name="dynamic_q_list" type="NX_NUMBER" units="NX_PER_LENGTH" minOccurs="0">
             <doc>
             1-D list of $Q$ values, 1 for each ROI.
+
+            List order is determined by the index value of the associated roi map starting at ``1``.
             </doc>
           </field>
           <field name="dynamic_phi_list" type="NX_NUMBER" units="NX_PER_LENGTH" minOccurs="0">
             <doc>
-            Array of $\varphi$ value for each pixel.
+            Array of $\varphi$ value for each pixel. 
+
+            List order is determined by the index value of the associated roi map starting at ``1``.
             </doc>
           </field>
           <field name="static_roi_map" type="NX_DIMENSIONLESS" minOccurs="0">

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -254,7 +254,8 @@
           subset of frame weighted average along the diagonal direction in ``two_time_corr_func``
 
           Time slicing along the diagonal can be very sophisticated.  This entry currently assumes 
-          equal frame-binning. The expected data formats are **VERY UNCERTAIN HERE AND NEED FEEDBACK**:
+          equal frame-binning. The expected data formats are **VERY UNCERTAIN HERE AND NEED FEEDBACK, but 
+          maybe this isnt a problem if we allow for customization (e.g., NXdata 2Ddata decorators)**:
             <list type="bullet">
               <item>
                 <description>iterable list of linked files for each parial $g_2$ with 1 file per q </description>

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -152,6 +152,10 @@
     </group>
 
     <group type="NXdata" name="twotime" minOccurs="0">
+    <doc>
+      The results in this section are higher order intensity correlations or are lower dimensional correlations
+      derived from the intensity time-time correlation function (aka the two-time correlation function).
+    </doc>
       <!-- TODO: needs documentation -->
       <field name="two_time_corr_func" type="NX_NUMBER" units="NX_ANY" minOccurs="0" maxOccurs="1">
         <doc>
@@ -250,12 +254,23 @@
         </field>
         <field name="extent" type="NX_FLOAT" units="NX_LENGTH">
           <doc>Size (2-D) of the beam at this position.</doc>
-          <!-- FIXME: (h, v) or (v, h)?  State this in the docs-->
+          <!-- FIXME: (h, v) or (v, h)?  State this in the docs FOR EPICS AD, likeky v, h.  But seems CSX is (h,v) if looking
+          from the source's perspective at the face of the detector - see fig 11 and fig 12 of cxidb documentation-->
         </field>
       </group>
 
       <group type="NXdetector" name="detector">
-        <!-- TODO: needs documentation -WHAT KIND OF INFORAMTION DO WE WANT FOR NXdetector -->
+        <doc>
+          XPCS data is typically produced by an areadetector as a stack of 2D images. Sometimes
+          this data is represented in different ways (sparse arrays or photon event list), but this detail
+          is left to the analysis software.  Therefore, we only include We note that the image origin
+          (pixel coordinates (0,0)) are found at the top left of a single 2D image array. This 
+          is the standard expected by  <a href="https://cxidb.org/cxi.html">Coherent X-ray Imaging Data Bank</a>. 
+          See CXI version 1.6 and Maia, Nature Methods (2012). 
+        
+          Additionally, all but ``frame_time`` are inhereited from NXdetector. ``frame_time`` is used to 
+          convert ``delay_difference`` to seconds.  
+        </doc>
         <field name="description">
           <doc>Detector name.</doc>
         </field>

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -36,7 +36,7 @@
     </symbol>
   </symbols>
   <doc>
-    X-ray Photon Correlation Spectroscopy data (results).
+    X-ray Photon Correlation Spectroscopy (XPCS) data (results).
 
     The purpose of NXxpcs is to document and communicate an accepted vanacular for various XPCS data 
     in order to suppport development of community software tools.  The definition presented here only
@@ -46,6 +46,8 @@
     Additional fields may be added to XPCS results file (forrmally or informally).  It is expected 
     that this XPCS data will be part of multi-modal data set that could involve e.g. NXcansas or 
     1D and/or 2D data.
+
+    **QUESTION** it seems we are missing the "average" image. was this intensional?  
   </doc>
   <group type="NXentry" name="entry">
     <field name="definition">
@@ -109,15 +111,22 @@
             open-source XPCS librarys refer to these bins as "rois", which are not to be confused with 
             EPICS AreaDetector ROI. See usage guidelines for q_lists and roi_maps within <a href="/NXxpcs/entry/instrument/masks-group">mask</a>.
             <!-- TODO: ensure link to mask section on this page works -->
-            In short, $g_2$ should be ordered according to the q or roi index. The data should be in one
+            In short, $g_2$ should be ordered according to the roi_map value. The data should be in one
             of the following two formats:
             <list type="bullet">
               <item>
-                <description>iterable list of linked files for each $g_2$ </description>
+                <description>iterable list of linked files for each $g_2$ with 1 file per q </description>
               </item>
               <item>
                 <description>2D array with shape ($g_2$, q) </description>
               </item>
+
+              **QUESTION** should we add a sketch of g2 plot with error bars and delay_difference as 
+              an illustratory example?
+
+              **QUESTION** should we talk more about expected length of data (we have not length 
+              consistency checks).  These checks are probably up to developers, but by docummenting
+              here, maybe this makes it easier?
         </doc>
       </field>
       <field name="g2_stderr" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
@@ -143,7 +152,7 @@
           This is quantized difference so that the "step" between two consecutive
           frames is one frame (or step = dt = 1 frame)
 
-          It is the "quantized" delay time corresponding to the g2 correlation values.
+          It is the "quantized" delay time corresponding to the ``g2`` values.
 
           The unit of delay_differences is NX_INT for units of frames (i.e. integers) preferred,
           refer to NXdetector for conversion to time units. <!-- TODO make links for NX_INT and NXdetector -->
@@ -166,7 +175,7 @@
           .. math:: C(q, t_1, t_2) = \frac{ \langle I(q, t_1)I(q, t_2)\rangle }{ \langle I(q,t_1)\rangle \langle I(q,t_2)\rangle }
 
           in which time is quantized by frames. In short, this correlation function should be ordered 
-          according to the q or roi index with the origin of the 2D array at the lower left.  The data 
+          according to the q or roi index with the origin of the 2D array at the **lower left**.  The data 
           should be in one of the following two formats:
             <list type="bullet">
               <item>
@@ -178,6 +187,9 @@
 
           Other normalization methods may be applied, but the method will not be specfied in this 
           defintion. Some of these normalization methods result in a baseline value of ``0``, not ``1``.
+
+          **QUESTION** do we want to enforce lower left for origin? is this okay if the two-time 
+          origin is not consistent with the image origin?
 
 
         </doc>
@@ -195,13 +207,20 @@
         </attribute>
       </field>
       <field name="g2_from_two_time_corr_func" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
-        <doc>sum across diagonals in two_time_corr_func</doc>
+        <doc>
+          weighted average along the diagonal direction in two_time_corr_func
+          
+          **QUESTION** How do we deal with diagonal? Require inclusion (and leave to "fitter"
+            to elminate it from exponential fit), require exclusion, allow for either with additional 
+            attribute?  We will appply this consistently to ``g2_from_two_time_corr_func_partials``
+        </doc>
         <attribute name="baseline_reference" type="NX_INT">
           <doc>
             baseline is the expected value of a full decorrelation
 
             The baseline is a constant value added to the functional form of the auto-correlatiton 
             function. This value is required.
+
           </doc>
           <enumeration>
           <item value="0"/>

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -38,7 +38,7 @@
   <doc>
     X-ray Photon Correlation Spectroscopy (XPCS) data (results).
 
-    The purpose of NXxpcs is to document and communicate an accepted vanacular for various XPCS data
+    The purpose of NXxpcs is to document and communicate an accepted vernacular for various XPCS data
     in order to suppport development of community software tools.  The definition presented here only
     represents a starting point and contains fields that a common software tool should support for
     community acceptance.
@@ -47,7 +47,7 @@
     that this XPCS data will be part of multi-modal data set that could involve e.g. NXcansas or
     1D and/or 2D data.
 
-    **QUESTION** it seems we are missing the "average" image. was this intensional?
+    **QUESTION** it seems we are missing the "average" image. was this intentional?
   </doc>
   <group type="NXentry" name="entry">
     <field name="definition">
@@ -397,7 +397,7 @@
             roi index array or labeled array
 
             The values of this mask index (or map to) the :math:`Q` value from the
-            the ``dynamic_q_list`` field. Not that the value of ``0`` represents in-action. XPCS compuatations
+            the ``dynamic_q_list`` field. Not that the value of ``0`` represents in-action. XPCS computations
             are performed on all pixels with a value > 0.
 
             The ``units`` attribute should be set to ``"au"``

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -135,7 +135,7 @@
               here, maybe this makes it easier?
         </doc>
       </field>
-      <field name="g2_stderr" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
+      <field name="g2_derr" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
         <doc>
             error values for the $g_2$ values. 
         
@@ -249,6 +249,14 @@
         </enumeration>
         </attribute>
       </field>
+      <field name="g2_err_from_two_time_corr_func" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
+        <doc>
+            error values for the $g_2$ values. 
+        
+            The derivation of the error is left up to the implemented code. Symmetric error will be
+            expected ($/pm$ error).  
+        </doc>
+      </field>
       <field name="g2_from_two_time_corr_func_partials" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
         <doc>
           subset of frame weighted average along the diagonal direction in ``two_time_corr_func``
@@ -281,6 +289,14 @@
           <item value="1"/>
         </enumeration>
         </attribute>
+      </field>
+      <field name="g2_err_from_two_time_corr_func_partials" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
+        <doc>
+            error values for the $g_2$ values. 
+        
+            The derivation of the error is left up to the implemented code. Symmetric error will be
+            expected ($/pm$ error).  
+        </doc>
       </field>
     </group>
 

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -173,8 +173,8 @@
                 <description>3D array with shape (frames, frames, q) </description>
               </item>
 
-          Other normalization methods may be applied, but the method will not be specfied in this defintion.
-          Some of these normalization methods result in a baseline value of 0, not 1.
+          Other normalization methods may be applied, but the method will not be specfied in this 
+          defintion. Some of these normalization methods result in a baseline value of 0, not 1.
 
 
         </doc>
@@ -182,8 +182,8 @@
           <doc>
             baseline is the expected value of a full decorrelation
 
-            The baseline is a constant value added to the functional form of the auto-correlatiton function.
-            This value is required.
+            The baseline is a constant value added to the functional form of the auto-correlatiton 
+            function. This value is required.
           </doc>
           <enumeration>
             <item value="0"/>
@@ -197,8 +197,8 @@
           <doc>
             baseline is the expected value of a full decorrelation
 
-            The baseline is a constant value added to the functional form of the auto-correlatiton function.
-            This value is required.
+            The baseline is a constant value added to the functional form of the auto-correlatiton 
+            function. This value is required.
           </doc>
           <enumeration>
           <item value="0"/>
@@ -212,8 +212,8 @@
           <doc>
             baseline is the expected value of a full decorrelation
 
-            The baseline is a constant value added to the functional form of the auto-correlatiton function.
-            This value is required.
+            The baseline is a constant value added to the functional form of the auto-correlatiton 
+            function. This value is required.
           </doc>
           <enumeration>
           <item value="0"/>

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -309,15 +309,27 @@
 
       <group type="NXnote" name="masks" minOccurs="0" maxOccurs="1">
           <doc>
-              Data masks or mappings to regions of interest (roi).
+              Data masks or mappings to regions of interest (roi) for specific $Q$ values
 
               Fields in this ``masks`` group describe regions of interest
               in the data by either a mask to select pixels or to associate
               a *map* of ROIs with a (one-dimensional) *list* of values.
+
+              "roi_maps" provide for represention of pixel binning that are arbitrary and irregular, 
+              which is geometry scattering agnostic and most flexible.
+
+              "Dynamic" represents quantities directly related to XPCS and NXxcps/entry/data and 
+              NXxpcs/entry/two_time.  
+              
+              "Static" refers to finerbinning used for computation not directly related to the final
+              XPCS results. Implementation of "static" binning is left for individual libraries to 
+              document.  We encouurage usage of NXcansas to represent standard SAXS results or
+              developmnet of new NeXus defintions for GI-SAXS or other reciprocal space
+              intensity mapping.
           </doc>
           <field name="dynamic_roi_map" type="NX_DIMENSIONLESS">
             <doc>
-            ROI index array, or labeled array.
+            roi index array or labeled array
 
             The values of this mask index (or map to) the $Q$ value from the
             the ``dynamic_q_list`` field. Not that the value of ``0`` represents in-action. XPCS compuatations 
@@ -329,9 +341,21 @@
           </field>
           <field name="dynamic_q_list" type="NX_NUMBER" units="NX_PER_LENGTH" minOccurs="0">
             <doc>
-            1-D list of $Q$ values, 1 for each ROI.
+            1-D list of $Q$ values, one for each roi index value.
 
             List order is determined by the index value of the associated roi map starting at ``1``.
+
+            The only requirement for the list is that it may be iterable. Some expected formats are:
+            <list type="bullet">
+              <item>
+                <description>iterable list of floats (i.e., $Q(r)$) </description>
+              </item>
+              <item>
+                <description>iterable list of tuples (e.g., (H, K, L); (qx, qy, qz); (horizontal_pixel, vertical_pixel)) </description>
+              </item>
+              <item>
+                <description>iterable list of integers or strings  </description>
+              </item>
             </doc>
           </field>
           <field name="dynamic_phi_list" type="NX_NUMBER" units="NX_PER_LENGTH" minOccurs="0">
@@ -343,7 +367,7 @@
           </field>
           <field name="static_roi_map" type="NX_DIMENSIONLESS" minOccurs="0">
             <doc>
-            ROI index array.
+            roi index array.
 
             The values of this mask index the $|Q|$ value from the
             the ``static_q_list`` field.

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -156,7 +156,6 @@
       The results in this section are higher order intensity correlations or are lower dimensional correlations
       derived from the intensity time-time correlation function (aka the two-time correlation function).
     </doc>
-      <!-- TODO: needs documentation -->
       <field name="two_time_corr_func" type="NX_NUMBER" units="NX_ANY" minOccurs="0" maxOccurs="1">
         <doc>
           two-time correlation of speckle intensity for a given q-bin or roi
@@ -385,7 +384,6 @@
     </group>
   
     <group type="NXsample" name="sample" minOccurs="0">
-      <!-- TODO: needs documentation -->
       Describes the minimum requirements regarding equilbrium sample conditions. NXsample
       permits other quantities (e.g., applied fields, crystallographic information, name, etc) that 
       may optionally be include for equilibrium conditions (which is not exclusively equilibrium

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -386,6 +386,13 @@
   
     <group type="NXsample" name="sample" minOccurs="0">
       <!-- TODO: needs documentation -->
+      Describes the minimum requirements regarding equilbrium sample conditions. NXsample
+      permits other quantities (e.g., applied fields, crystallographic information, name, etc) that 
+      may optionally be include for equilibrium conditions (which is not exclusively equilibrium
+      dynamics from XPCS analysis).
+
+      For non-equilibrrium sample conditions (i.e., changing sample or process conditions 
+      during the XPCS measurement) will require either a new entry or an additional atttribute.
       <field name="temperature_set" type="NX_NUMBER" units="NX_TEMPERATURE" minOccurs="0">
         <doc>
           Sample temperature setpoint, (C or K).
@@ -406,7 +413,7 @@
         Region(s) of interest.
 
         NAME: The NeXus convention, to use all upper case
-        to indicate the name (here ``ROI``), is left to the file 
+        to indicate the name (here ``roi``), is left to the file 
         writer.  In our case, follow the suggested name
         pattern and sequence: roi_1, roi_2, roi_3, ...
         Start with ``roi_1`` if the first one, otherwise

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -217,7 +217,7 @@
       </field>
       <field name="g2_from_two_time_corr_func" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
         <doc>
-          weighted average along the diagonal direction in ``two_time_corr_func``
+          frame weighted average along the diagonal direction in ``two_time_corr_func``
 
           The data should be in one of the following two formats:
             <list type="bullet">
@@ -227,6 +227,9 @@
               <item>
                 <description>2D array with shape ($g_2$, q) </description>
               </item>
+
+            Note that delay_difference is not included here because it is derived from the shape of
+            extrated $g_2$.
             
           **QUESTION** How do we deal with diagonal? Require inclusion (and leave to "fitter"
             to elminate it from exponential fit), require exclusion, allow for either with additional 
@@ -248,7 +251,7 @@
       </field>
       <field name="g2_from_two_time_corr_func_partials" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
         <doc>
-          subset of weighted average along the diagonal direction in ``two_time_corr_func``
+          subset of frame weighted average along the diagonal direction in ``two_time_corr_func``
 
           Time slicing along the diagonal can be very sophisticated.  This entry currently assumes 
           equal frame-binning. The expected data formats are **VERY UNCERTAIN HERE AND NEED FEEDBACK**:
@@ -260,6 +263,9 @@
                 <description>3D array with shape ($g_2$, q, frame_binned_group) </description>
               </item>
 
+          Note that delay_difference is not included here because it is derived from the shape of
+          extrated $g_2$.
+            
           **QUESTION** Do we want a simple illustration of a two-time with markings showing bin boundaries?
         </doc>
         <attribute name="baseline_reference" type="NX_INT">

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -103,6 +103,21 @@
             normalized intensity auto-correlation function, see Lumma, Rev. Sci. Instr. (2000), Eq 1
             
             ..  math:: g_2(Q,t) = \frac{ \langle I(Q,t\prime) I(Q,t|prime = t) \rangle }{ \langle I(Q,t\prime)\rangle^2 }; t > 0
+
+            Typically, $g_2$ is a quantity calculated for a group of pixels reprenting a specific region
+            of reciprocal space.  These groupings, or bins, are generically desribed as q. Some open-source XPCS
+            librarys refer to these bins as "rois", which are not to be confused with EPICS AreaDetector ROI.
+            See usage guidelines for q_lists and roi_maps within <a href="/NXxpcs/entry/instrument/masks-group">mask</a>.
+
+            In short, $g_2$ should be ordered according to the q or roi index. The data should be in one
+            of the following two formats:
+            <list type="bullet">
+              <item>
+                <description>iterable list of linked files to each $g_2$ </description>
+              </item>
+              <item>
+                <description>2D array with shape ($g_2$, q) </description>
+              </item>
         </doc>
       </field>
       <field name="g2_stderr" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -38,16 +38,16 @@
   <doc>
     X-ray Photon Correlation Spectroscopy (XPCS) data (results).
 
-    The purpose of NXxpcs is to document and communicate an accepted vernacular for various XPCS data
+    The purpose of ``NXxpcs`` is to document and communicate an accepted vernacular for various XPCS data
     in order to suppport development of community software tools.  The definition presented here only
     represents a starting point and contains fields that a common software tool should support for
     community acceptance.
 
-    Additional fields may be added to XPCS results file (forrmally or informally).  It is expected
+    Additional fields may be added to XPCS results file (either formally or informally).  It is expected
     that this XPCS data will be part of multi-modal data set that could involve e.g. NXcansas or
     1D and/or 2D data.
 
-    **QUESTION** it seems we are missing the "average" image. was this intentional?
+    **QUESTION** it seems we are missing the "average" image. Was this intentional?
   </doc>
   <group type="NXentry" name="entry">
     <field name="definition">
@@ -223,7 +223,7 @@
             extracted :math:`g_2`.
 
           **QUESTION** How do we deal with diagonal? Require inclusion (and leave to "fitter"
-            to elminate it from exponential fit), require exclusion, allow for either with additional
+            to eliminate it from exponential fit), require exclusion, allow for either with additional
             attribute?  We will appply this consistently to ``g2_from_two_time_corr_func_partials``
         </doc>
         <attribute name="baseline_reference" type="NX_INT">

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -38,16 +38,16 @@
   <doc>
     X-ray Photon Correlation Spectroscopy (XPCS) data (results).
 
-    The purpose of NXxpcs is to document and communicate an accepted vanacular for various XPCS data 
+    The purpose of NXxpcs is to document and communicate an accepted vanacular for various XPCS data
     in order to suppport development of community software tools.  The definition presented here only
-    represents a starting point and contains fields that a common software tool should support for 
+    represents a starting point and contains fields that a common software tool should support for
     community acceptance.
 
-    Additional fields may be added to XPCS results file (forrmally or informally).  It is expected 
-    that this XPCS data will be part of multi-modal data set that could involve e.g. NXcansas or 
+    Additional fields may be added to XPCS results file (forrmally or informally).  It is expected
+    that this XPCS data will be part of multi-modal data set that could involve e.g. NXcansas or
     1D and/or 2D data.
 
-    **QUESTION** it seems we are missing the "average" image. was this intensional?  
+    **QUESTION** it seems we are missing the "average" image. was this intensional?
   </doc>
   <group type="NXentry" name="entry">
     <field name="definition">
@@ -103,44 +103,43 @@
       <field name="g2" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
         <doc>
             normalized intensity auto-correlation function, see Lumma, Rev. Sci. Instr. (2000), Eq 1
-            
+
             ..  math:: g_2(Q,t) = \frac{ \langle I(Q,t\prime) I(Q,t|prime = t) \rangle }{ \langle I(Q,t\prime)\rangle^2 }; t > 0
 
-            Typically, $g_2$ is a quantity calculated for a group of pixels reprenting a specific 
-            region of reciprocal space.  These groupings, or bins, are generically desribed as q. Some 
-            open-source XPCS librarys refer to these bins as "rois", which are not to be confused with 
-            EPICS AreaDetector ROI. See usage guidelines for q_lists and roi_maps within 
-            <a href="/NXxpcs/entry/instrument/masks-group">mask</a>.
-            <!-- TODO: ensure link to mask section on this page works -->
-            In short, $g_2$ should be ordered according to the roi_map value. The data should be in one
+            Typically, :math:`g_2` is a quantity calculated for a group of pixels reprenting a specific
+            region of reciprocal space.  These groupings, or bins, are generically desribed as :math:`q`. Some
+            open-source XPCS librarys refer to these bins as "rois", which are not to be confused with
+            EPICS AreaDetector ROI. See usage guidelines for q_lists and roi_maps within a mask.  [#]_
+
+            In short, :math:`g_2` should be ordered according to the roi_map value. The data should be in one
             of the following two formats:
-            <list type="bullet">
-              <item>
-                <description>iterable list of linked files for each $g_2$ with 1 file per q </description>
-              </item>
-              <item>
-                <description>2D array with shape ($g_2$, q) </description>
-              </item>
 
-              **QUESTION** enforcing array shape/order seems like a bad idea. NeXus has away to 
-              tag the positions. <a href="https://manual.nexusformat.org/classes/base_classes/NXdata.html#nxdata"> 2Ddata</a>
-            
-              **QUESTIION** should we add an attriibute for data method (list of file links versus arrays)?
+            * iterable list of linked files for each :math:`g_2` with 1 file per :math:`q`
+            * 2D array with shape (:math:`g_2`, :math:`q`)
 
-              **QUESTION** should we add a sketch of g2 plot with error bars, delay_difference, and 
-              baseline as an illustratory example?
+            **QUESTION** enforcing array shape/order seems like a bad idea. NeXus has a way [#]_ to
+            tag the positions.
 
-              **QUESTION** should we talk more about expected length of data (we have not length 
-              consistency checks).  These checks are probably up to developers, but by docummenting
-              here, maybe this makes it easier?
+            **QUESTION** should we add an attribute for data method (list of file links versus arrays)?
+
+            **QUESTION** should we add a sketch of g2 plot with error bars, delay_difference, and
+            baseline as an illustratory example?
+
+            **QUESTION** should we talk more about expected length of data (we have not length
+            consistency checks).  These checks are probably up to developers, but by docummenting
+            here, maybe this makes it easier?
+
+            .. TODO the next line should cite an anchor on this page about "mask".
+            .. [#] mask: ``/NXxpcs/entry/instrument/masks-group``
+            .. [#] NeXus 2-D data: https://manual.nexusformat.org/classes/base_classes/NXdata.html#nxdata
         </doc>
       </field>
       <field name="g2_derr" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
         <doc>
-            error values for the $g_2$ values. 
-        
+            error values for the :math:`g_2` values.
+
             The derivation of the error is left up to the implemented code. Symmetric error will be
-            expected ($/pm$ error).  The data should be in the same format as ``g2``.
+            expected (:math:`\pm` error).  The data should be in the same format as ``g2``.
         </doc>
       </field>
       <field name="G2_unnormalized" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
@@ -148,13 +147,13 @@
             unnormalized intensity auto-correlation function.
 
             Specifically ``g2`` without the denominator.  The data should be in the same format as ``g2``.
-            
+
         </doc>
       </field>
       <field name="delay_difference" type="NX_INT" units="NX_INT" minOccurs="0" maxOccurs="1">
         <doc>
-          delay_difference (also known as delay or lag step) 
-          
+          delay_difference (also known as delay or lag step)
+
           This is quantized difference so that the "step" between two consecutive
           frames is one frame (or step = dt = 1 frame)
 
@@ -174,27 +173,23 @@
       <field name="two_time_corr_func" type="NX_NUMBER" units="NX_ANY" minOccurs="0" maxOccurs="1">
         <doc>
           two-time correlation of speckle intensity for a given q-bin or roi
-          
-          See Fluerasu, Phys Rev E (2007), Eq 1 and Sutton, Optics Express (2003) for the most basic 
+
+          See Fluerasu, Phys Rev E (2007), Eq 1 and Sutton, Optics Express (2003) for the most basic
           description:
 
           .. math:: C(q, t_1, t_2) = \frac{ \langle I(q, t_1)I(q, t_2)\rangle }{ \langle I(q,t_1)\rangle \langle I(q,t_2)\rangle }
 
-          in which time is quantized by frames. In short, this correlation function should be ordered 
-          according to the q or roi index with the origin of the 2D array at the **lower left**.  The data 
+          in which time is quantized by frames. In short, this correlation function should be ordered
+          according to the q or roi index with the origin of the 2D array at the **lower left**.  The data
           should be in one of the following two formats:
-            <list type="bullet">
-              <item>
-                <description>iterable list of linked files for each q-bin, which is a 2D array.  </description>
-              </item>
-              <item>
-                <description>3D array with shape (frames, frames, q) </description>
-              </item>
 
-          Other normalization methods may be applied, but the method will not be specfied in this 
+          * iterable list of linked files for each q-bin, which is a 2D array.
+          * 3D array with shape (frames, frames, q)
+
+          Other normalization methods may be applied, but the method will not be specfied in this
           defintion. Some of these normalization methods result in a baseline value of ``0``, not ``1``.
 
-          **QUESTION** do we want to enforce lower left for origin? is this okay if the two-time 
+          **QUESTION** do we want to enforce lower left for origin? is this okay if the two-time
           origin is not consistent with the image origin? We will add an example 2time
 
           **QUESTION** 8ID data has only half populated 2time (to save on data).  Seems we need
@@ -206,7 +201,7 @@
           <doc>
             baseline is the expected value of a full decorrelation
 
-            The baseline is a constant value added to the functional form of the auto-correlatiton 
+            The baseline is a constant value added to the functional form of the auto-correlatiton
             function. This value is required.
           </doc>
           <enumeration>
@@ -220,26 +215,22 @@
           frame weighted average along the diagonal direction in ``two_time_corr_func``
 
           The data should be in one of the following two formats:
-            <list type="bullet">
-              <item>
-                <description>iterable list of linked files for each $g_2$ with 1 file per q </description>
-              </item>
-              <item>
-                <description>2D array with shape ($g_2$, q) </description>
-              </item>
+
+          * iterable list of linked files for each :math:`g_2` with 1 file per :math:`q`
+          * 2D array with shape (:math:`g_2`, :math:`q`)
 
             Note that delay_difference is not included here because it is derived from the shape of
-            extrated $g_2$.
-            
+            extracted :math:`g_2`.
+
           **QUESTION** How do we deal with diagonal? Require inclusion (and leave to "fitter"
-            to elminate it from exponential fit), require exclusion, allow for either with additional 
+            to elminate it from exponential fit), require exclusion, allow for either with additional
             attribute?  We will appply this consistently to ``g2_from_two_time_corr_func_partials``
         </doc>
         <attribute name="baseline_reference" type="NX_INT">
           <doc>
             baseline is the expected value of a full decorrelation
 
-            The baseline is a constant value added to the functional form of the auto-correlatiton 
+            The baseline is a constant value added to the functional form of the auto-correlatiton
             function. This value is required.
 
           </doc>
@@ -251,37 +242,33 @@
       </field>
       <field name="g2_err_from_two_time_corr_func" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
         <doc>
-            error values for the $g_2$ values. 
-        
+            error values for the :math:`g_2` values.
+
             The derivation of the error is left up to the implemented code. Symmetric error will be
-            expected ($/pm$ error).  
+            expected (:math:`\pm` error).
         </doc>
       </field>
       <field name="g2_from_two_time_corr_func_partials" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
         <doc>
           subset of frame weighted average along the diagonal direction in ``two_time_corr_func``
 
-          Time slicing along the diagonal can be very sophisticated.  This entry currently assumes 
-          equal frame-binning. The expected data formats are **VERY UNCERTAIN HERE AND NEED FEEDBACK, but 
-          maybe this isnt a problem if we allow for customization (e.g., NXdata 2Ddata decorators)**:
-            <list type="bullet">
-              <item>
-                <description>iterable list of linked files for each parial $g_2$ with 1 file per q </description>
-              </item>
-              <item>
-                <description>3D array with shape ($g_2$, q, frame_binned_group) </description>
-              </item>
+          Time slicing along the diagonal can be very sophisticated.  This entry currently assumes
+          equal frame-binning. The expected data formats are **VERY UNCERTAIN HERE AND NEED FEEDBACK, but
+          maybe this isn't a problem if we allow for customization (e.g., NXdata 2Ddata attributes)**:
+
+          * iterable list of linked files for each parial :math:`g_2` with 1 file per :math:`q`
+          * 3D array with shape (:math:`g_2`, :math:`q`, frame_binned_group)
 
           Note that delay_difference is not included here because it is derived from the shape of
-          extrated $g_2$.
-            
+          extrated :math:`g_2`.
+
           **QUESTION** Do we want a simple illustration of a two-time with markings showing bin boundaries?
         </doc>
         <attribute name="baseline_reference" type="NX_INT">
           <doc>
             baseline is the expected value of a full decorrelation
 
-            The baseline is a constant value added to the functional form of the auto-correlatiton 
+            The baseline is a constant value added to the functional form of the auto-correlatiton
             function. This value is required.
           </doc>
           <enumeration>
@@ -292,10 +279,10 @@
       </field>
       <field name="g2_err_from_two_time_corr_func_partials" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
         <doc>
-            error values for the $g_2$ values. 
-        
+            error values for the :math:`g_2` values.
+
             The derivation of the error is left up to the implemented code. Symmetric error will be
-            expected ($/pm$ error).  
+            expected (:math:`\pm` error).
         </doc>
       </field>
     </group>
@@ -313,7 +300,7 @@
         </field>
         <field name="incident_energy_spread" type="NX_FLOAT" units="NX_ENERGY">
           <doc>
-            Spread of incident beam line energy (either keV or eV). This quantity is otherwise known 
+            Spread of incident beam line energy (either keV or eV). This quantity is otherwise known
             as the energy resolution, which is related to the longitudinal coherence length.
           </doc>
         </field>
@@ -337,12 +324,12 @@
           XPCS data is typically produced by an areadetector as a stack of 2D images. Sometimes
           this data is represented in different ways (sparse arrays or photon event list), but this detail
           is left to the analysis software.  Therefore, we only include We note that the image origin
-          (pixel coordinates (0,0)) are found at the top left of a single 2D image array. This 
-          is the standard expected by  <a href="https://cxidb.org/cxi.html">Coherent X-ray Imaging Data Bank</a>. 
-          See CXI version 1.6 and Maia, Nature Methods (2012). 
-        
-          Additionally, all but ``frame_time`` are inhereited from NXdetector. ``frame_time`` is used to 
-          convert ``delay_difference`` to seconds.  
+          (pixel coordinates (0,0)) are found at the top left of a single 2D image array. This
+          is the standard expected by  <a href="https://cxidb.org/cxi.html">Coherent X-ray Imaging Data Bank</a>.
+          See CXI version 1.6 and Maia, Nature Methods (2012).
+
+          Additionally, all but ``frame_time`` are inhereited from NXdetector. ``frame_time`` is used to
+          convert ``delay_difference`` to seconds.
 
           **QUESTION** It seems this top-left is matplotlib default and informal convention of AreaDetector.
           However, in reading the CXI documentation, top-left is the example in Fig 11. Fig 12 shows
@@ -387,20 +374,20 @@
 
       <group type="NXnote" name="masks" minOccurs="0" maxOccurs="1">
           <doc>
-              Data masks or mappings to regions of interest (roi) for specific $Q$ values
+              Data masks or mappings to regions of interest (roi) for specific :math:`Q` values
 
               Fields in this ``masks`` group describe regions of interest
               in the data by either a mask to select pixels or to associate
               a *map* of ROIs with a (one-dimensional) *list* of values.
 
-              "roi_maps" provide for represention of pixel binning that are arbitrary and irregular, 
+              "roi_maps" provide for represention of pixel binning that are arbitrary and irregular,
               which is geometry scattering agnostic and most flexible.
 
-              "Dynamic" represents quantities directly related to XPCS and NXxcps/entry/data and 
-              NXxpcs/entry/two_time.  
-              
+              "Dynamic" represents quantities directly related to XPCS and NXxcps/entry/data and
+              NXxpcs/entry/two_time.
+
               "Static" refers to finerbinning used for computation not directly related to the final
-              XPCS results. Implementation of "static" binning is left for individual libraries to 
+              XPCS results. Implementation of "static" binning is left for individual libraries to
               document.  We encouurage usage of NXcansas to represent standard SAXS results or
               developmnet of new NeXus defintions for GI-SAXS or other reciprocal space
               intensity mapping.
@@ -409,8 +396,8 @@
             <doc>
             roi index array or labeled array
 
-            The values of this mask index (or map to) the $Q$ value from the
-            the ``dynamic_q_list`` field. Not that the value of ``0`` represents in-action. XPCS compuatations 
+            The values of this mask index (or map to) the :math:`Q` value from the
+            the ``dynamic_q_list`` field. Not that the value of ``0`` represents in-action. XPCS compuatations
             are performed on all pixels with a value > 0.
 
             The ``units`` attribute should be set to ``"au"``
@@ -419,26 +406,20 @@
           </field>
           <field name="dynamic_q_list" type="NX_NUMBER" units="NX_PER_LENGTH" minOccurs="0">
             <doc>
-            1-D list of $Q$ values, one for each roi index value.
+            1-D list of :math:`Q` values, one for each roi index value.
 
             List order is determined by the index value of the associated roi map starting at ``1``.
 
             The only requirement for the list is that it may be iterable. Some expected formats are:
-            <list type="bullet">
-              <item>
-                <description>iterable list of floats (i.e., $Q(r)$) </description>
-              </item>
-              <item>
-                <description>iterable list of tuples (e.g., (H, K, L); (qx, qy, qz); (horizontal_pixel, vertical_pixel)) </description>
-              </item>
-              <item>
-                <description>iterable list of integers or strings  </description>
-              </item>
+
+            * iterable list of floats (i.e., :math:`Q(r)`)
+            * iterable list of tuples (e.g., (H, K, L); (qx, qy, qz); (horizontal_pixel, vertical_pixel))
+            * iterable list of integers or strings
             </doc>
           </field>
           <field name="dynamic_phi_list" type="NX_NUMBER" units="NX_PER_LENGTH" minOccurs="0">
             <doc>
-            Array of $\varphi$ value for each pixel. 
+            Array of :math:`\varphi` value for each pixel.
 
             List order is determined by the index value of the associated roi map starting at ``1``.
             </doc>
@@ -447,7 +428,7 @@
             <doc>
             roi index array.
 
-            The values of this mask index the $|Q|$ value from the
+            The values of this mask index the :math:`|Q|` value from the
             the ``static_q_list`` field.
 
             The ``units`` attribute should be set to ``"au"``
@@ -456,19 +437,19 @@
           </field>
           <field name="static_q_list" type="NX_NUMBER" units="NX_PER_LENGTH">
             <doc>
-            1-D list of $|Q|$ values, 1 for each ROI.
+            1-D list of :math:`|Q|` values, 1 for each ROI.
             </doc>
           </field>
       </group>
     </group>
-  
+
     <group type="NXsample" name="sample" minOccurs="0">
       Describes the minimum requirements regarding equilbrium sample conditions. NXsample
-      permits other quantities (e.g., applied fields, crystallographic information, name, etc) that 
+      permits other quantities (e.g., applied fields, crystallographic information, name, etc) that
       may optionally be include for equilibrium conditions (which is not exclusively equilibrium
       dynamics from XPCS analysis).
 
-      For non-equilibrrium sample conditions (i.e., changing sample or process conditions 
+      For non-equilibrrium sample conditions (i.e., changing sample or process conditions
       during the XPCS measurement) will require either a new entry or an additional atttribute.
       <field name="temperature_set" type="NX_NUMBER" units="NX_TEMPERATURE" minOccurs="0">
         <doc>
@@ -490,7 +471,7 @@
         Region(s) of interest.
 
         NAME: The NeXus convention, to use all upper case
-        to indicate the name (here ``roi``), is left to the file 
+        to indicate the name (here ``roi``), is left to the file
         writer.  In our case, follow the suggested name
         pattern and sequence: roi_1, roi_2, roi_3, ...
         Start with ``roi_1`` if the first one, otherwise
@@ -503,7 +484,7 @@
         Any other notes.
 
         NAME: The NeXus convention, to use all upper case
-        to indicate the name (here ``NOTE``), is left to the file 
+        to indicate the name (here ``NOTE``), is left to the file
         writer.  In our case, follow the suggested name
         pattern and sequence: note_1, note_2, note_3, ...
         Start with ``note_1`` if the first one, otherwise

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -104,10 +104,10 @@
             
             ..  math:: g_2(Q,t) = \frac{ \langle I(Q,t\prime) I(Q,t|prime = t) \rangle }{ \langle I(Q,t\prime)\rangle^2 }; t > 0
 
-            Typically, $g_2$ is a quantity calculated for a group of pixels reprenting a specific region
-            of reciprocal space.  These groupings, or bins, are generically desribed as q. Some open-source XPCS
-            librarys refer to these bins as "rois", which are not to be confused with EPICS AreaDetector ROI.
-            See usage guidelines for q_lists and roi_maps within <a href="/NXxpcs/entry/instrument/masks-group">mask</a>.
+            Typically, $g_2$ is a quantity calculated for a group of pixels reprenting a specific 
+            region of reciprocal space.  These groupings, or bins, are generically desribed as q. Some 
+            open-source XPCS librarys refer to these bins as "rois", which are not to be confused with 
+            EPICS AreaDetector ROI. See usage guidelines for q_lists and roi_maps within <a href="/NXxpcs/entry/instrument/masks-group">mask</a>.
             <!-- TODO: ensure link to mask section on this page works -->
             In short, $g_2$ should be ordered according to the q or roi index. The data should be in one
             of the following two formats:
@@ -155,14 +155,34 @@
       <!-- TODO: needs documentation -->
       <field name="two_time_corr_func" type="NX_NUMBER" units="NX_ANY" minOccurs="0" maxOccurs="1">
         <doc>
-          two-time correlation see Fluerasu, Phys Rev E (2007), Eq 1 and Sutton, Optics Express (2003)
+          two-time correlation of speckle intensity for a given q-bin or roi
+          
+          See Fluerasu, Phys Rev E (2007), Eq 1 and Sutton, Optics Express (2003) for the most basic 
+          description:
 
           .. math:: C(q, t_1, t_2) = \frac{ \langle I(q, t_1)I(q, t_2)\rangle }{ \langle I(q,t_1)\rangle \langle I(q,t_2)\rangle }
+
+          in which time is quantized by frames. In short, this correlation function should be ordered 
+          according to the q or roi index with the origin of the 2D array at the lower left.  The data 
+          should be in one of the following two formats:
+            <list type="bullet">
+              <item>
+                <description>iterable list of linked files for each q-bin, which is a 2D array.  </description>
+              </item>
+              <item>
+                <description>3D array with shape (frames, frames, q) </description>
+              </item>
+
+          Other normalization methods may be applied, but the method will not be specfied in this defintion.
+          Some of these normalization methods result in a baseline value of 0, not 1.
+
+
         </doc>
         <attribute name="baseline_reference" type="NX_INT">
           <doc>
-            The baseline is the expected value of a full decorrelation.
-            Will be used as a constant value in fitting.
+            baseline is the expected value of a full decorrelation
+
+            The baseline is a constant value added to the functional form of the auto-correlatiton function.
             This value is required.
           </doc>
           <enumeration>
@@ -175,8 +195,9 @@
         <doc>sum across diagonals in two_time_corr_func</doc>
         <attribute name="baseline_reference" type="NX_INT">
           <doc>
-            The baseline is the expected value of a full decorrelation.
-            Will be used as a constant value in fitting.
+            baseline is the expected value of a full decorrelation
+
+            The baseline is a constant value added to the functional form of the auto-correlatiton function.
             This value is required.
           </doc>
           <enumeration>
@@ -189,8 +210,9 @@
         <doc>subset of sum across diagonals in two_time_corr_func</doc>
         <attribute name="baseline_reference" type="NX_INT">
           <doc>
-            The baseline is the expected value of a full decorrelation.
-            Will be used as a constant value in fitting.
+            baseline is the expected value of a full decorrelation
+
+            The baseline is a constant value added to the functional form of the auto-correlatiton function.
             This value is required.
           </doc>
           <enumeration>
@@ -214,7 +236,8 @@
         </field>
         <field name="incident_energy_spread" type="NX_FLOAT" units="NX_ENERGY">
           <doc>
-            Spread of incident beam line energy (either keV or eV).
+            Spread of incident beam line energy (either keV or eV). This quantity is otherwise known as the energy resolution, 
+            which is related to the longitudinal coherence length.
           </doc>
         </field>
         <field name="incident_polarization_type">
@@ -232,7 +255,7 @@
       </group>
 
       <group type="NXdetector" name="detector">
-        <!-- TODO: needs documentation -->
+        <!-- TODO: needs documentation -WHAT KIND OF INFORAMTION DO WE WANT FOR NXdetector -->
         <field name="description">
           <doc>Detector name.</doc>
         </field>

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -122,17 +122,17 @@
       </field>
       <field name="g2_stderr" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
         <doc>
-            error values for the g2 values. 
+            error values for the $g_2$ values. 
         
             The derivation of the error is left up to the implemented code. Symmetric error will be
-            expected ($/pm$ error).  The data should be in the same format as "g2".
+            expected ($/pm$ error).  The data should be in the same format as ``g2``.
         </doc>
       </field>
       <field name="G2_unnormalized" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
         <doc>
             unnormalized intensity auto-correlation function.
 
-            Specifically "g2" without the denominator.  The data should be in the same format as "g2".
+            Specifically ``g2`` without the denominator.  The data should be in the same format as ``g2``.
             
         </doc>
       </field>
@@ -174,7 +174,7 @@
               </item>
 
           Other normalization methods may be applied, but the method will not be specfied in this 
-          defintion. Some of these normalization methods result in a baseline value of 0, not 1.
+          defintion. Some of these normalization methods result in a baseline value of ``0``, not ``1``.
 
 
         </doc>
@@ -236,8 +236,8 @@
         </field>
         <field name="incident_energy_spread" type="NX_FLOAT" units="NX_ENERGY">
           <doc>
-            Spread of incident beam line energy (either keV or eV). This quantity is otherwise known as the energy resolution, 
-            which is related to the longitudinal coherence length.
+            Spread of incident beam line energy (either keV or eV). This quantity is otherwise known 
+            as the energy resolution, which is related to the longitudinal coherence length.
           </doc>
         </field>
         <field name="incident_polarization_type">

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -195,7 +195,10 @@
           defintion. Some of these normalization methods result in a baseline value of ``0``, not ``1``.
 
           **QUESTION** do we want to enforce lower left for origin? is this okay if the two-time 
-          origin is not consistent with the image origin?
+          origin is not consistent with the image origin? We will add an example 2time
+
+          **QUESTION** 8ID data has only half populated 2time (to save on data).  Seems we need
+          an attribute for this as well.
 
 
         </doc>
@@ -317,6 +320,11 @@
         
           Additionally, all but ``frame_time`` are inhereited from NXdetector. ``frame_time`` is used to 
           convert ``delay_difference`` to seconds.  
+
+          **QUESTION** It seems this top-left is matplotlib default and informal convention of AreaDetector.
+          However, in reading the CXI documentation, top-left is the example in Fig 11. Fig 12 shows
+          it is perspective dependant. We need to make a decision here - do we always convert or do
+          we add attributes that allows someone to convert to CXI format (speckle oversampling for single frame CDI)
         </doc>
         <field name="description">
           <doc>Detector name.</doc>

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -109,7 +109,8 @@
             Typically, $g_2$ is a quantity calculated for a group of pixels reprenting a specific 
             region of reciprocal space.  These groupings, or bins, are generically desribed as q. Some 
             open-source XPCS librarys refer to these bins as "rois", which are not to be confused with 
-            EPICS AreaDetector ROI. See usage guidelines for q_lists and roi_maps within <a href="/NXxpcs/entry/instrument/masks-group">mask</a>.
+            EPICS AreaDetector ROI. See usage guidelines for q_lists and roi_maps within 
+            <a href="/NXxpcs/entry/instrument/masks-group">mask</a>.
             <!-- TODO: ensure link to mask section on this page works -->
             In short, $g_2$ should be ordered according to the roi_map value. The data should be in one
             of the following two formats:
@@ -120,6 +121,11 @@
               <item>
                 <description>2D array with shape ($g_2$, q) </description>
               </item>
+
+              **QUESTION** enforcing array shape/order seems like a bad idea. NeXus has away to 
+              tag the positions. <a href="https://manual.nexusformat.org/classes/base_classes/NXdata.html#nxdata"> 2Ddata</a>
+            
+              **QUESTIION** should we add an attriibute for data method (list of file links versus arrays)?
 
               **QUESTION** should we add a sketch of g2 plot with error bars, delay_difference, and 
               baseline as an illustratory example?
@@ -208,8 +214,17 @@
       </field>
       <field name="g2_from_two_time_corr_func" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
         <doc>
-          weighted average along the diagonal direction in two_time_corr_func
-          
+          weighted average along the diagonal direction in ``two_time_corr_func``
+
+          The data should be in one of the following two formats:
+            <list type="bullet">
+              <item>
+                <description>iterable list of linked files for each $g_2$ with 1 file per q </description>
+              </item>
+              <item>
+                <description>2D array with shape ($g_2$, q) </description>
+              </item>
+            
           **QUESTION** How do we deal with diagonal? Require inclusion (and leave to "fitter"
             to elminate it from exponential fit), require exclusion, allow for either with additional 
             attribute?  We will appply this consistently to ``g2_from_two_time_corr_func_partials``
@@ -229,7 +244,21 @@
         </attribute>
       </field>
       <field name="g2_from_two_time_corr_func_partials" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
-        <doc>subset of sum across diagonals in two_time_corr_func</doc>
+        <doc>
+          subset of weighted average along the diagonal direction in ``two_time_corr_func``
+
+          Time slicing along the diagonal can be very sophisticated.  This entry currently assumes 
+          equal frame-binning. The expected data formats are **VERY UNCERTAIN HERE AND NEED FEEDBACK**:
+            <list type="bullet">
+              <item>
+                <description>iterable list of linked files for each parial $g_2$ with 1 file per q </description>
+              </item>
+              <item>
+                <description>3D array with shape ($g_2$, q, frame_binned_group) </description>
+              </item>
+
+          **QUESTION** Do we want a simple illustration of a two-time with markings showing bin boundaries?
+        </doc>
         <attribute name="baseline_reference" type="NX_INT">
           <doc>
             baseline is the expected value of a full decorrelation

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -38,8 +38,14 @@
   <doc>
     X-ray Photon Correlation Spectroscopy data (results).
 
-    It is expected that this XPCS data will be part of multi-modal data set that could involve e.f. NXcansas
-    or 1D and/or 2D data.
+    The purpose of NXxpcs is to document and communicate an accepted vanacular for various XPCS data 
+    in order to suppport development of community software tools.  The definition presented here only
+    represents a starting point and contains fields that a common software tool should support for 
+    community acceptance.
+
+    Additional fields may be added to XPCS results file (forrmally or informally).  It is expected 
+    that this XPCS data will be part of multi-modal data set that could involve e.g. NXcansas or 
+    1D and/or 2D data.
   </doc>
   <group type="NXentry" name="entry">
     <field name="definition">

--- a/NeXus/NXxpcs.nxdl.xml
+++ b/NeXus/NXxpcs.nxdl.xml
@@ -108,12 +108,12 @@
             of reciprocal space.  These groupings, or bins, are generically desribed as q. Some open-source XPCS
             librarys refer to these bins as "rois", which are not to be confused with EPICS AreaDetector ROI.
             See usage guidelines for q_lists and roi_maps within <a href="/NXxpcs/entry/instrument/masks-group">mask</a>.
-
+            <!-- TODO: ensure link to mask section on this page works -->
             In short, $g_2$ should be ordered according to the q or roi index. The data should be in one
             of the following two formats:
             <list type="bullet">
               <item>
-                <description>iterable list of linked files to each $g_2$ </description>
+                <description>iterable list of linked files for each $g_2$ </description>
               </item>
               <item>
                 <description>2D array with shape ($g_2$, q) </description>
@@ -121,18 +121,32 @@
         </doc>
       </field>
       <field name="g2_stderr" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
-        <doc>standard deviation error values for the g2 values</doc>
+        <doc>
+            error values for the g2 values. 
+        
+            The derivation of the error is left up to the implemented code. Symmetric error will be
+            expected ($/pm$ error).  The data should be in the same format as "g2".
+        </doc>
       </field>
       <field name="G2_unnormalized" type="NX_NUMBER" units="NX_ARBITRARY_UNITS" minOccurs="0" maxOccurs="1">
-        <doc>unnormalized intensity auto-correlation function</doc>
+        <doc>
+            unnormalized intensity auto-correlation function.
+
+            Specifically "g2" without the denominator.  The data should be in the same format as "g2".
+            
+        </doc>
       </field>
       <field name="delay_difference" type="NX_INT" units="NX_INT" minOccurs="0" maxOccurs="1">
         <doc>
-          delay_difference (also known as delay or lag) quantized difference so that the "step" between two consecutive
+          delay_difference (also known as delay or lag step) 
+          
+          This is quantized difference so that the "step" between two consecutive
           frames is one frame (or step = dt = 1 frame)
-          It is the delay time corresponding to the g2 correlation values.
+
+          It is the "quantized" delay time corresponding to the g2 correlation values.
+
           The unit of delay_differences is NX_INT for units of frames (i.e. integers) preferred,
-          refer to NXdetector for conversion to time units
+          refer to NXdetector for conversion to time units. <!-- TODO make links for NX_INT and NXdetector -->
         </doc>
       </field>
     </group>

--- a/NeXus/README.md
+++ b/NeXus/README.md
@@ -3,7 +3,7 @@
 `NXxpcs` describes the structure of a NeXus/HDF5 datafile used to
 describe XPCS results computed by software external (to the [Bluesky
 framework](https://blueskyproject.io/)) and to import those results into
-Bluesky for visualization and other activities. Additionally, any independant 
+Bluesky for visualization and other activities. Additionally, any independent 
 project that wishes to support the XPCS community may use this definition as
 a minimum requirements guide to building a more universal tool.
 

--- a/NeXus/README.md
+++ b/NeXus/README.md
@@ -4,8 +4,8 @@
 describe XPCS results computed by software external (to the [Bluesky
 framework](https://blueskyproject.io/)) and to import those results into
 Bluesky for visualization and other activities. Additionally, any independant 
-project that wishes to support the XPCS community may use this definition a
-a guide to building a more universal tool.
+project that wishes to support the XPCS community may use this definition as
+a minimum requirements guide to building a more universal tool.
 
 In this repository, we prepare the `NXxpcs` application _before_ we
 submit it to the [NeXus definitions

--- a/NeXus/README.md
+++ b/NeXus/README.md
@@ -3,7 +3,9 @@
 `NXxpcs` describes the structure of a NeXus/HDF5 datafile used to
 describe XPCS results computed by software external (to the [Bluesky
 framework](https://blueskyproject.io/)) and to import those results into
-Bluesky for visualization and other activities.
+Bluesky for visualization and other activities. Additionally, any independant 
+project that wishes to support the XPCS community may use this definition a
+a guide to building a more universal tool.
 
 In this repository, we prepare the `NXxpcs` application _before_ we
 submit it to the [NeXus definitions


### PR DESCRIPTION
made changes within `/NeXus`.  mostly added more descriptive text, but this exercise uncovered a few questions.

### Major changes
* changed `g2_stderr` to `g2_err` to make it more generic
--------- XPCS Eigen uses standard deviation in custom implementation based on their method. 
--------- skbeam requires end user to "experimentally" determine this 
--------- there is a mathematical-based error propagation method that can be employed
* added error fields in `NXxpcs/entry/twotime` for extracted g2.  this is NOT standard deviation so we should not label it as such.

### Intentions for next version release
* add pictures after this version release because future discussion could influence picture selection
* added **QUESTIONS** for entire group to discuss

### Next major decisions
* how to deal with horizontal / vertical axis of 2D data
* how to deal with 2d image origin
* how to deal with 3D+ array data
* how to deal with linked files versus array data
* how to deal phi list


anyone should edit here if I have missed something
